### PR TITLE
fix AttributeError: 'DataFrame' object has no attribute 'to_dense'. S…

### DIFF
--- a/SCNIC/correlation_analysis.py
+++ b/SCNIC/correlation_analysis.py
@@ -74,7 +74,8 @@ def run_fastspar(otu_table_loc, correl_table_loc, covar_table_loc, stdout=None, 
 def fastspar_correlation(table: Table, verbose: bool=False, calc_pvalues=False, bootstraps=1000, nprocs=1,
                          p_adjust_method='fdr_bh') -> pd.DataFrame:
     with tempfile.TemporaryDirectory(prefix='fastspar') as temp:
-        table.to_dataframe().to_dense().to_csv(path.join(temp, 'otu_table.tsv'), sep='\t', index_label='#OTU ID')
+        # To fix AttributeError: 'DataFrame' object has no attribute 'to_dense'. See: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sparse.to_dense.html
+        table.to_dataframe().sparse.to_dense().to_csv(path.join(temp, 'otu_table.tsv'), sep='\t', index_label='#OTU ID')
         if verbose:
             stdout = None
         else:


### PR DESCRIPTION
fix AttributeError: 'DataFrame' object has no attribute 'to_dense'. See: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sparse.to_dense.html

I encountered this issue when using q2-SCNIC plugin for QIIME2. I hope this helps!
![image](https://user-images.githubusercontent.com/37885260/103341689-904cdf80-4ac2-11eb-921e-b300ed283f23.png)
