### PR TITLE
Fix error in .sparse.to_dense() function from correlation script

### DIFF
--- a/SCNIC/correlation_analysis.py
+++ b/SCNIC/correlation_analysis.py
@@ -74,7 +74,7 @@ def run_fastspar(otu_table_loc, correl_table_loc, covar_table_loc, stdout=None, 
 def fastspar_correlation(table: Table, verbose: bool=False, calc_pvalues=False, bootstraps=1000, nprocs=1,
                          p_adjust_method='fdr_bh') -> pd.DataFrame:
     with tempfile.TemporaryDirectory(prefix='fastspar') as temp:
-        table.to_dataframe().to_dense().to_csv(path.join(temp, 'otu_table.tsv'), sep='\t', index_label='#OTU ID')
+        table.to_dataframe().sparse.to_dense().to_csv(path.join(temp, 'otu_table.tsv'), sep='\t', index_label='#OTU ID')
         if verbose:
             stdout = None
         else:


### PR DESCRIPTION
The previous version did not contain the ".sparse." term and therefore presented errors.
This function now is compatible with pandas' newest versions and does not conflict with the core python function.